### PR TITLE
feat: added multiple floors generation removing last tile

### DIFF
--- a/IceRunner/Assets/Scenes/Basics.unity
+++ b/IceRunner/Assets/Scenes/Basics.unity
@@ -350,7 +350,7 @@ MonoBehaviour:
   - {fileID: 8863254488261516915, guid: 23ddec8ef3b831849b6919d2e8553b89, type: 3}
   - {fileID: 6806192569075084592, guid: c9640515251e1654484773549bbd825f, type: 3}
   player: {fileID: 1710185589}
-  maxFloors: 2
+  maxFloors: 3
   rotation: 10
 --- !u!1 &1710185584
 GameObject:

--- a/IceRunner/Assets/Scenes/Basics.unity
+++ b/IceRunner/Assets/Scenes/Basics.unity
@@ -350,7 +350,7 @@ MonoBehaviour:
   - {fileID: 8863254488261516915, guid: 23ddec8ef3b831849b6919d2e8553b89, type: 3}
   - {fileID: 6806192569075084592, guid: c9640515251e1654484773549bbd825f, type: 3}
   player: {fileID: 1710185589}
-  maxFloors: 3
+  firstNFloors: 5
   rotation: 10
 --- !u!1 &1710185584
 GameObject:
@@ -409,11 +409,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9c34d6f0668824343b6a97726e1c6b32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveSpeed: 10
-  speedIncreaseRate: 0.1
-  maxMoveSpeed: 50
+  moveSpeed: 20
+  speedIncreaseRate: 0.2
+  maxMoveSpeed: 150
   gravity: -9.81
-  jumpHeight: 2
+  jumpHeight: 4
+  gravityFactor: 2
+  smoothingFactor: 5
 --- !u!143 &1710185588
 CharacterController:
   m_ObjectHideFlags: 0

--- a/IceRunner/Assets/Scripts/SpawnManager.cs
+++ b/IceRunner/Assets/Scripts/SpawnManager.cs
@@ -10,9 +10,8 @@ public class SpawnManager : MonoBehaviour
 
     public List<GameObject> floorPrefabs;       // Referenz auf das Floor-Prefab
     public Transform player;            // Referenz auf den Spieler
-
     private List<GameObject> activeFloors = new List<GameObject>(); // Liste der aktiven Floors
-    public int maxFloors = 2;          // Anzahl der Floors, die gleichzeitig existieren sollen
+    public int maxFloors = 3;          // Anzahl der Floors, die gleichzeitig existieren sollen
     public float rotation = 10f;
 
 
@@ -43,28 +42,29 @@ public class SpawnManager : MonoBehaviour
 
     public void SpawnNewFloor(Transform currentFloor)
     {
-        var randomTileFromList = RandomFloorFromList();
-        
-        // Berechne die Position und Rotation des neuen Floors
-        Vector3 newPosition = currentFloor.position + currentFloor.forward * currentFloor.localScale.z;
-        Quaternion newRotation = currentFloor.rotation;
-
-        // Erstelle den neuen Floor
-        // Erstelle den neuen Floor und füge ihn zur Liste hinzu
-        GameObject newFloor = Instantiate(randomTileFromList, newPosition, newRotation);
-        activeFloors.Add(newFloor);
-
-        // Aktualisiere die Spielerrotation
-        //UpdatePlayerRotation(rotation);
-
-        // Wenn die Anzahl der Floors das Maximum überschreitet, lösche den ältesten Floor
-        if (activeFloors.Count > maxFloors)
+        Transform lastFloor = currentFloor; // Start mit dem aktuellen Boden
+        destroyLastTile(currentFloor); // Löscht immer den letzten Floor hinter dem Player
+        if (activeFloors.Count == 1) // Beim letzten Tile erst die neuen Tiles generieren
         {
-            GameObject oldFloor = activeFloors[0]; // Ältester Floor
-            activeFloors.RemoveAt(0);
-            Destroy(oldFloor);
+            for (int i = 0; i < maxFloors; i++)
+            {
+                // Wähle eine zufällige Tile aus der Liste
+                var randomTileFromList = RandomFloorFromList();
+
+                // Berechne die Position und Rotation für den neuen Boden
+                Vector3 newPosition = lastFloor.position + lastFloor.forward.normalized * GetTileLength(lastFloor.gameObject);
+                Quaternion newRotation = lastFloor.rotation;
+
+                // Erstelle den neuen Boden
+                GameObject newFloor = Instantiate(randomTileFromList, newPosition, newRotation);
+                activeFloors.Add(newFloor);
+
+                // Setze den zuletzt erstellten Boden als Referenz für den nächsten
+                lastFloor = newFloor.transform;
+            }
         }
     }
+
 
     private void UpdatePlayerRotation(float floorRotation)
     {
@@ -72,10 +72,42 @@ public class SpawnManager : MonoBehaviour
         Quaternion playerRotation = Quaternion.Euler(floorRotation, 0f, 0f);
         player.rotation = playerRotation;
     }
-    
+
     private GameObject RandomFloorFromList()
     {
         return floorPrefabs[Random.Range(0, floorPrefabs.Count)];
     }
+
+    private void destroyLastTile(Transform currentFloor)
+    {
+        if (activeFloors.Count > 1 && currentFloor.position != Vector3.zero)
+        {
+            GameObject oldFloor = activeFloors[0]; // Ältester Floor
+            activeFloors.RemoveAt(0);
+            Destroy(oldFloor);
+        }
+    }
+
+    // Hilfsmethode, um die Länge eines Tiles zu ermitteln
+    private float GetTileLength(GameObject tile)
+    {
+        // Versuche zuerst, die Länge aus dem Collider zu berechnen
+        BoxCollider collider = tile.GetComponent<BoxCollider>();
+        if (collider != null)
+        {
+            return collider.size.z * tile.transform.localScale.z;
+        }
+
+        // Alternativ: Länge aus dem Renderer berechnen
+        Renderer renderer = tile.GetComponent<Renderer>();
+        if (renderer != null)
+        {
+            return renderer.bounds.size.z;
+        }
+
+        // Fallback: Standardwert für Tile Länge (falls keine Länge ermittelt werden kann)
+        return 50f;
+    }
+
 
 }

--- a/IceRunner/Assets/Scripts/TriggerFloorGen.cs
+++ b/IceRunner/Assets/Scripts/TriggerFloorGen.cs
@@ -11,8 +11,16 @@ public class TriggerFloorGen : MonoBehaviour
         {
             hasTriggered = true;
 
-            // Spawne einen neuen Floor, wenn der Spieler den Trigger betritt
-            SpawnManager.Instance.SpawnNewFloor(transform.parent);
+            if (transform.parent.position == Vector3.zero) //Beim Trigger vom ersten Floor im Game
+            {
+                // Spawne n neue Floors, wenn der Spieler den ersten Trigger betritt
+                SpawnManager.Instance.SpawnFirstNFloors(transform.parent);
+            }
+            else
+            {
+                // Spawne n neue Floors, wenn der Spieler den ersten Trigger betritt
+                SpawnManager.Instance.SpawnNewFloor(transform.parent);
+            }
         }
     }
 }

--- a/IceRunner/Assets/Scripts/movement.cs
+++ b/IceRunner/Assets/Scripts/movement.cs
@@ -10,12 +10,15 @@ public class movement : MonoBehaviour
 
     Vector2 moveDirection = Vector2.zero;
     Vector3 movePlayer = Vector3.zero;
-    [SerializeField] private float moveSpeed = 0.5f;
-    [SerializeField] private float speedIncreaseRate = 0.1f; // acceleration as time flies
-    [SerializeField] private int maxMoveSpeed = 50;
+    [SerializeField] private float moveSpeed = 20f;
+    [SerializeField] private float speedIncreaseRate = 0.2f; // acceleration as time flies
+    [SerializeField] private int maxMoveSpeed = 150;
     [SerializeField] private float gravity = -9.81f;
-    [SerializeField] private float jumpHeight = 2f;
+    [SerializeField] private float jumpHeight = 4f;
+    [SerializeField] private float gravityFactor = 2f;
+    [SerializeField] private float smoothingFactor = 5f; // Wie schnell die Bewegung reagiert
 
+    private float smoothedMoveX = 0f;
     private float currentMoveSpeed;
     private Vector3 velocity;
     private bool canJump = true;
@@ -58,7 +61,13 @@ public class movement : MonoBehaviour
         }
 
         moveDirection = move.ReadValue<Vector2>();
-        movePlayer = this.transform.right * moveDirection.x + this.transform.forward;
+
+        // Glättung der horizontalen Bewegung
+        smoothedMoveX = Mathf.Lerp(smoothedMoveX, moveDirection.x, Time.deltaTime * smoothingFactor);
+
+        // Bewegungsrichtung mit geglätteter horizontaler Eingabe
+        movePlayer = this.transform.right * smoothedMoveX + this.transform.forward;
+        
         playerController.Move(movePlayer * currentMoveSpeed * Time.deltaTime);
 
         // Jump logic
@@ -69,7 +78,7 @@ public class movement : MonoBehaviour
         }
 
         // apply gravity
-        velocity.y += gravity * Time.deltaTime;
+        velocity.y += gravity * Time.deltaTime * gravityFactor;
         playerController.Move(velocity * Time.deltaTime);
     }
 }


### PR DESCRIPTION
Now everytime the player enters a trigger, the last tile behind him will be destroyed (more efficient).
Now the maxFloors Variabe of the SpawnManager tells, how many Tiles should be generated at the same time (default 3). When the player hits the last Trigger of the the third generated Tile, then again 3 Tiles are generated an so on. 
Can be modified later when it is finalized how many Tiles should be generated.