### PR TITLE
feat: Add session coin count UI and logic

### DIFF
--- a/IceRunner/Assets/Scenes/Level.unity
+++ b/IceRunner/Assets/Scenes/Level.unity
@@ -473,6 +473,7 @@ MonoBehaviour:
   pauseMenu: {fileID: 338995514}
   currentCoinCount: {fileID: 129977684}
   highScoreGroup: {fileID: 1596122959}
+  sessionCoinCount: {fileID: 852574317}
   coinCount: {fileID: 1449571537}
   highScore: {fileID: 1305577779}
 --- !u!1 &460640491
@@ -769,7 +770,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 564963797}
-  - component: {fileID: 564963798}
   m_Layer: 5
   m_Name: GameendMenu
   m_TagString: Untagged
@@ -799,23 +799,142 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &564963798
+--- !u!1 &613802458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 613802459}
+  - component: {fileID: 613802461}
+  - component: {fileID: 613802460}
+  m_Layer: 5
+  m_Name: SessionCoinsCount
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &613802459
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613802458}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 852574318}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 62.99994, y: 2.0000305}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &613802460
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 564963796}
+  m_GameObject: {fileID: 613802458}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c9dfcbee40b674b678c0ad332376a8f4, type: 3}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pauseMenu: {fileID: 564963796}
-  currentCoinCount: {fileID: 129977684}
-  highScoreGroup: {fileID: 1596122959}
-  coinCount: {fileID: 1449571537}
-  highScore: {fileID: 1305577779}
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 60
+  m_fontSizeBase: 60
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: -20.656458, z: -153.8955, w: -16.47158}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &613802461
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613802458}
+  m_CullTransparentMesh: 1
 --- !u!1 &656699052
 GameObject:
   m_ObjectHideFlags: 0
@@ -1176,6 +1295,43 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7351545943075352904, guid: d30cde8beaaba6149966a46135cb5223, type: 3}
   m_PrefabInstance: {fileID: 811998863}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &852574317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 852574318}
+  m_Layer: 5
+  m_Name: SessionCoins
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &852574318
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 852574317}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1180375584}
+  - {fileID: 613802459}
+  m_Father: {fileID: 1469112077}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -773, y: 474}
+  m_SizeDelta: {x: 326, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1085127514
 GameObject:
   m_ObjectHideFlags: 0
@@ -1297,6 +1453,81 @@ MonoBehaviour:
   player: {fileID: 1710185589}
   firstNFloors: 3
   rotation: 10
+--- !u!1 &1180375583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1180375584}
+  - component: {fileID: 1180375586}
+  - component: {fileID: 1180375585}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1180375584
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1180375583}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 852574318}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -113, y: -0.000091552734}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1180375585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1180375583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4afd6628b8efe4a7f8af42e676ff63ce, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1180375586
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1180375583}
+  m_CullTransparentMesh: 1
 --- !u!1 &1220809104
 GameObject:
   m_ObjectHideFlags: 0
@@ -1379,7 +1610,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 564963798}
+      - m_Target: {fileID: 338995516}
         m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
         m_MethodName: Home
         m_Mode: 1
@@ -1937,6 +2168,7 @@ RectTransform:
   - {fileID: 129977685}
   - {fileID: 1596122960}
   - {fileID: 1292154404}
+  - {fileID: 852574318}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2300,6 +2532,7 @@ MonoBehaviour:
   - Coin
   coinAudioSource: {fileID: 1710185596}
   coinPickupSound: {fileID: 8300000, guid: 1191d028ac2f5584ea1663b9cbfe3aa5, type: 3}
+  sessionCoinCount: {fileID: 613802460}
 --- !u!114 &1710185591
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2328,6 +2561,8 @@ MonoBehaviour:
   dayNightCycle: {fileID: 1721942727}
   GameendScreen: {fileID: 564963796}
   gameendOverviewText: {fileID: 1749932482}
+  sessionCoinCount: {fileID: 852574317}
+  isAlive: 1
 --- !u!114 &1710185593
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/IceRunner/Assets/Scripts/Collectable.cs
+++ b/IceRunner/Assets/Scripts/Collectable.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using TMPro;
 
 public class Collectable : MonoBehaviour
 {
@@ -8,6 +9,7 @@ public class Collectable : MonoBehaviour
     public static Collectable Instance { get; private set; }
     public AudioSource coinAudioSource;
     public AudioClip coinPickupSound;
+    [SerializeField] public TextMeshProUGUI sessionCoinCount;
 
     private void Start()
     {
@@ -66,6 +68,14 @@ public class Collectable : MonoBehaviour
 
         collectibles[itemName] += amount;
 
+        // Coins collected till round end
+        if (!collectibles.ContainsKey("sessionCoin"))
+        {
+            collectibles["sessionCoin"] = 0;
+        }
+        collectibles["sessionCoin"] += amount;
+        updateSessionCoinCount();
+
         if (itemName == "Coin")
         {
             PlayerPrefs.SetInt("CoinCount", collectibles[itemName]);
@@ -108,5 +118,13 @@ public class Collectable : MonoBehaviour
             return collectibles["Coin"];
         }
         return 0;
+    }
+
+    private void updateSessionCoinCount()
+    {
+        if (sessionCoinCount != null)
+        {
+            sessionCoinCount.text = collectibles["sessionCoin"].ToString();
+        }
     }
 }

--- a/IceRunner/Assets/Scripts/PauseMenu.cs
+++ b/IceRunner/Assets/Scripts/PauseMenu.cs
@@ -8,14 +8,16 @@ public class PauseMenu : MonoBehaviour
     [SerializeField] GameObject pauseMenu;
     [SerializeField] GameObject currentCoinCount;
     [SerializeField] GameObject highScoreGroup;
+    [SerializeField] GameObject sessionCoinCount;
     [SerializeField] public TextMeshProUGUI coinCount;
     [SerializeField] public TextMeshProUGUI highScore;
     private bool isPaused = false;
 
+
     private void Update()
     {
         Debug.Log("Update method called");
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetKeyDown(KeyCode.Escape) && PlayerCollision.Instance.isAlive)
         {
             if (isPaused)
             {
@@ -34,6 +36,7 @@ public class PauseMenu : MonoBehaviour
         pauseMenu.SetActive(true);
         currentCoinCount.SetActive(true);
         highScoreGroup.SetActive(true);
+        sessionCoinCount.SetActive(false);
         isPaused = true;
         UpdateCoinDisplay();
         UpdateHighScoreDisplay();
@@ -44,6 +47,7 @@ public class PauseMenu : MonoBehaviour
         pauseMenu.SetActive(false);
         currentCoinCount.SetActive(false);
         highScoreGroup.SetActive(false);
+        sessionCoinCount.SetActive(true);
         Time.timeScale = 1;
         isPaused = false;
     }

--- a/IceRunner/Assets/Scripts/PlayerCollision.cs
+++ b/IceRunner/Assets/Scripts/PlayerCollision.cs
@@ -8,7 +8,23 @@ public class PlayerCollision : MonoBehaviour
     public DayNightCycle dayNightCycle;
     public GameObject GameendScreen;
     [SerializeField] public TextMeshProUGUI gameendOverviewText;
+    public GameObject sessionCoinCount;
     private bool _isInvincible = false;
+    public static PlayerCollision Instance;
+    public bool isAlive = true;
+
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
 
     private void OnTriggerEnter(Collider other)
     {
@@ -28,11 +44,14 @@ public class PlayerCollision : MonoBehaviour
 
     private void PlayerDied()
     {
-        GameManager.Instance.IncreaseSpeed(20f);
+        // GameManager.Instance.IncreaseSpeed(20f);
         Debug.Log("Player Died!");
+        this.isAlive = false;
         dayNightCycle.EndDay();
-        Destroy(gameObject);
+        // Destroy(gameObject);
+        Time.timeScale = 0;
         GameendScreen.SetActive(true);
+        sessionCoinCount.SetActive(false);
         gameendOverviewText.text = $"Well Played! \n Your high score is {GameManager.Instance.GetSavedHighScore()}! \n You have collected {Collectable.Instance.GetCoinCount()} coins!";
     }
 


### PR DESCRIPTION
- Added `sessionCoinCount` UI element to track coins collected during the current session.
- Updated `Collectable` script to manage session coin count and display it via `TextMeshProUGUI`.
- Modified `PauseMenu` to toggle session coin visibility when pausing/unpausing.
- Updated `PlayerCollision` to ensure session coin count is hidden when the player dies.
- Added logic to initialize and update session coin count across different game states.